### PR TITLE
docker -p port range is wrong in "run_with_prebuilt_image.md"

### DIFF
--- a/docs/run_with_prebuilt_image.md
+++ b/docs/run_with_prebuilt_image.md
@@ -12,7 +12,7 @@
 2. Start a container
 
     ```
-    docker run -it -p 35300-35400:35300-35400 tencentailab/hok_env:cpu_v2.0.1 bash
+    docker run -it -p 35000-35400:35000-35400 tencentailab/hok_env:cpu_v2.0.1 bash
     ```
 
 3. set the gamecore


### PR DESCRIPTION
The cmd in `run_with_prebuilt_image.md` is 
```shell
docker run -it -p 35300-35400:35300-35400 tencentailab/hok_env:cpu_v2.0.1 bash
```
But port in code `test_env.py` is:
```python
for i in range(AGENT_NUM):
        addrs.append("tcp://0.0.0.0:{}".format(35150 + i))
```
This causes the test fail to run.
So it should be:
```shell
docker run -it -p 35000-35400:35000-35400 tencentailab/hok_env:cpu_v2.0.1 bash
```