### PR TITLE
fix: module hok has no attribute hok1v1 issue in #67

### DIFF
--- a/hok_env/hok/hok1v1/env1v1.py
+++ b/hok_env/hok/hok1v1/env1v1.py
@@ -15,7 +15,7 @@ class ResponceType(Enum):
 
 
 import numpy as np
-import hok.hok1v1.lib.interface as interface
+from hok.hok1v1.lib import interface as interface
 from hok.common.log import logger as LOG
 
 interface_default_config = os.path.join(os.path.dirname(__file__), "config.dat")


### PR DESCRIPTION
Solved issue #67  by replace import way in `hok_env/hok_env/hok/hok1v1/env1v1.py`

```
# import hok.hok1v1.lib.interface as interface
# replace with
from hok.hok1v1.lib import interface as interface
```